### PR TITLE
Fix ADF conversion annotations and docs

### DIFF
--- a/docs/adf-ast-implementation.md
+++ b/docs/adf-ast-implementation.md
@@ -21,7 +21,7 @@ The MCP Atlassian server now uses an AST (Abstract Syntax Tree) based approach f
 3. **Plugin Architecture** (`adf_plugins.py`)
    - Extensible system for adding custom ADF nodes
    - Supports both block and inline plugins
-   - Currently includes 8 built-in plugins
+   - Currently includes 10 built-in plugins
 
 4. **FormatRouter** (`router.py`)
    - Routes content to appropriate formatter based on deployment type
@@ -214,7 +214,7 @@ Validation levels:
    ```python
    # Old
    from mcp_atlassian.formatting.adf import ADFGenerator
-   
+
    # New (backward compatible)
    from mcp_atlassian.formatting.adf_ast import ASTBasedADFGenerator as ADFGenerator
    ```

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -307,16 +307,16 @@ class PagesMixin(ConfluenceClient):
             # Determine body and representation based on content type
             if is_markdown:
                 # Convert markdown to appropriate Confluence format (ADF for Cloud, storage for Server/DC)
-                result = self.preprocessor.markdown_to_confluence(
+                converted_body = self.preprocessor.markdown_to_confluence(
                     body, enable_heading_anchors=enable_heading_anchors
                 )
-                if isinstance(result, dict):
+                if isinstance(converted_body, dict):
                     # ADF format for Cloud instances
-                    final_body = result
+                    final_body = converted_body
                     representation = "atlas_doc_format"
                 else:
                     # Storage format for Server/DC instances
-                    final_body = result
+                    final_body = converted_body
                     representation = "storage"
             else:
                 # Use body as-is with specified representation
@@ -399,16 +399,16 @@ class PagesMixin(ConfluenceClient):
             # Determine body and representation based on content type
             if is_markdown:
                 # Convert markdown to appropriate Confluence format (ADF for Cloud, storage for Server/DC)
-                result = self.preprocessor.markdown_to_confluence(
+                converted_body = self.preprocessor.markdown_to_confluence(
                     body, enable_heading_anchors=enable_heading_anchors
                 )
-                if isinstance(result, dict):
+                if isinstance(converted_body, dict):
                     # ADF format for Cloud instances
-                    final_body = result
+                    final_body = converted_body
                     representation = "atlas_doc_format"
                 else:
                     # Storage format for Server/DC instances
-                    final_body = result
+                    final_body = converted_body
                     representation = "storage"
             else:
                 # Use body as-is with specified representation

--- a/src/mcp_atlassian/formatting/adf.py
+++ b/src/mcp_atlassian/formatting/adf.py
@@ -1,7 +1,7 @@
 """ADF (Atlassian Document Format) generator for converting markdown to ADF JSON.
 
-This module provides functionality to convert markdown text to ADF format that is 
-required by Jira and Confluence Cloud APIs. It uses a visitor pattern to transform 
+This module provides functionality to convert markdown text to ADF format that is
+required by Jira and Confluence Cloud APIs. It uses a visitor pattern to transform
 markdown AST nodes into proper ADF JSON structure.
 
 Performance optimizations:
@@ -17,7 +17,7 @@ import time
 from functools import lru_cache
 from typing import Any
 
-import markdown
+import markdown  # type: ignore[import]
 
 from .adf_validator import ADFValidator, get_validation_level
 
@@ -26,52 +26,44 @@ logger = logging.getLogger(__name__)
 
 class ADFGenerator:
     """Generator for converting markdown text to Atlassian Document Format (ADF) JSON.
-    
+
     Performance optimizations:
     - LRU cache for frequently converted patterns (maxsize=256)
     - Performance metrics collection for monitoring
     - Graceful error handling with fallback mechanisms
     """
 
-    def __init__(self, cache_size: int = 256, max_table_rows: int = 50, 
-                 max_list_items: int = 100) -> None:
+    def __init__(
+        self, cache_size: int = 256, max_table_rows: int = 50, max_list_items: int = 100
+    ) -> None:
         """Initialize the ADF generator with markdown parser and performance optimizations.
-        
+
         Args:
             cache_size: Maximum size of the conversion cache (default: 256)
             max_table_rows: Maximum number of table rows before truncation (default: 50)
             max_list_items: Maximum number of list items before truncation (default: 100)
         """
         self.md = markdown.Markdown(
-            extensions=[
-                'codehilite',
-                'tables',
-                'fenced_code',
-                'nl2br',
-                'toc'
-            ],
+            extensions=["codehilite", "tables", "fenced_code", "nl2br", "toc"],
             extension_configs={
-                'codehilite': {
-                    'css_class': 'codehilite',
-                    'use_pygments': False
-                }
-            }
+                "codehilite": {"css_class": "codehilite", "use_pygments": False}
+            },
         )
-        
+
         # Configurable limits
         self.max_table_rows = max_table_rows
         self.max_list_items = max_list_items
-        
+
         # Initialize validator
         self.validator = ADFValidator(validation_level=get_validation_level())
 
         # Performance metrics
         self.metrics: dict[str, Any] = {
-            'conversions_total': 0,
-            'conversions_cached': 0,
-            'conversion_time_total': 0.0,
-            'conversion_errors': 0,
-            'last_error': None
+            "conversions_total": 0,
+            "conversions_cached": 0,
+            "conversion_time_total": 0.0,
+            "conversion_errors": 0,
+            "last_error": None,
         }
 
         # Configure caching based on cache_size
@@ -80,58 +72,65 @@ class ADFGenerator:
     def _configure_cache(self, cache_size: int) -> None:
         """Configure LRU cache for markdown conversion."""
         # Create cached version of _convert_markdown_to_adf
-        self._cached_convert = lru_cache(maxsize=cache_size)(self._convert_markdown_to_adf_uncached)
+        self._cached_convert = lru_cache(maxsize=cache_size)(
+            self._convert_markdown_to_adf_uncached
+        )
 
     def markdown_to_adf(self, markdown_text: str) -> dict[str, Any]:
         """
         Convert markdown text to ADF JSON format with caching and performance monitoring.
-        
+
         Args:
             markdown_text: Input markdown text to convert
-            
+
         Returns:
             Dictionary representing ADF JSON structure
-            
+
         Raises:
             ValueError: If markdown conversion fails after all fallback attempts
         """
         start_time = time.time()
-        self.metrics['conversions_total'] = self.metrics['conversions_total'] + 1
+        self.metrics["conversions_total"] = self.metrics["conversions_total"] + 1
 
         try:
             # Handle empty input efficiently
             if not markdown_text or not markdown_text.strip():
-                return {
-                    "type": "doc",
-                    "version": 1,
-                    "content": []
-                }
+                return {"type": "doc", "version": 1, "content": []}
 
             # Create cache key from input
-            cache_key = hashlib.md5(markdown_text.encode('utf-8')).hexdigest()
+            cache_key = hashlib.sha256(markdown_text.encode("utf-8")).hexdigest()
 
             # Try cached conversion first
             try:
                 result = self._cached_convert(cache_key, markdown_text)
-                self.metrics['conversions_cached'] = self.metrics['conversions_cached'] + 1
+                self.metrics["conversions_cached"] = (
+                    self.metrics["conversions_cached"] + 1
+                )
                 logger.debug(f"ADF conversion cache hit for key: {cache_key[:8]}...")
             except Exception as cache_error:
-                logger.warning(f"Cache error, falling back to direct conversion: {cache_error}")
+                logger.warning(
+                    f"Cache error, falling back to direct conversion: {cache_error}"
+                )
                 # Fall back to direct conversion
-                result = self._convert_markdown_to_adf_uncached(cache_key, markdown_text)
-            
+                result = self._convert_markdown_to_adf_uncached(
+                    cache_key, markdown_text
+                )
+
             # Validate the result
             is_valid, errors = self.validator.validate(result)
-            if not is_valid and self.validator.validation_level == ADFValidator.VALIDATION_ERROR:
+            if (
+                not is_valid
+                and self.validator.validation_level == ADFValidator.VALIDATION_ERROR
+            ):
                 # If validation fails in error mode, return error document
                 error_msg = "ADF validation failed: " + "; ".join(errors)
                 return self._create_error_adf(markdown_text, error_msg)
-            
+
             return result
 
         except Exception as e:
-            self.metrics['conversion_errors'] = self.metrics['conversion_errors'] + 1
-            self.metrics['last_error'] = str(e)
+            self.metrics["conversion_errors"] = self.metrics["conversion_errors"] + 1
+            self.metrics["last_error"] = str(e)
             logger.error(f"ADF conversion failed: {e}")
 
             # Graceful degradation: return a basic ADF with error information
@@ -140,19 +139,25 @@ class ADFGenerator:
         finally:
             # Update performance metrics
             conversion_time = time.time() - start_time
-            self.metrics['conversion_time_total'] = self.metrics['conversion_time_total'] + conversion_time
+            self.metrics["conversion_time_total"] = (
+                self.metrics["conversion_time_total"] + conversion_time
+            )
 
             if conversion_time > 0.1:  # Log slow conversions
-                logger.warning(f"Slow ADF conversion: {conversion_time:.3f}s for {len(markdown_text)} chars")
+                logger.warning(
+                    f"Slow ADF conversion: {conversion_time:.3f}s for {len(markdown_text)} chars"
+                )
 
-    def _convert_markdown_to_adf_uncached(self, cache_key: str, markdown_text: str) -> dict[str, Any]:
+    def _convert_markdown_to_adf_uncached(
+        self, cache_key: str, markdown_text: str
+    ) -> dict[str, Any]:
         """
         Internal method for actual ADF conversion (uncached version).
-        
+
         Args:
             cache_key: Cache key for this conversion (for logging)
             markdown_text: Input markdown text to convert
-            
+
         Returns:
             Dictionary representing ADF JSON structure
         """
@@ -169,11 +174,7 @@ class ADFGenerator:
             # Parse the HTML and convert to ADF
             adf_content = self._html_to_adf_content(html_output)
 
-            return {
-                "version": 1,
-                "type": "doc",
-                "content": adf_content
-            }
+            return {"version": 1, "type": "doc", "content": adf_content}
 
         except Exception as e:
             logger.error(f"Failed to convert markdown to ADF: {e}")
@@ -182,11 +183,7 @@ class ADFGenerator:
 
     def _create_empty_document(self) -> dict[str, Any]:
         """Create an empty ADF document."""
-        return {
-            "version": 1,
-            "type": "doc",
-            "content": []
-        }
+        return {"version": 1, "type": "doc", "content": []}
 
     def _create_plain_text_document(self, text: str) -> dict[str, Any]:
         """Create ADF document with plain text fallback."""
@@ -194,43 +191,37 @@ class ADFGenerator:
             "version": 1,
             "type": "doc",
             "content": [
-                {
-                    "type": "paragraph",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": text
-                        }
-                    ]
-                }
-            ]
+                {"type": "paragraph", "content": [{"type": "text", "text": text}]}
+            ],
         }
 
     def _html_to_adf_content(self, html: str) -> list[dict[str, Any]]:
         """
         Convert HTML to ADF content blocks.
-        
+
         This is a simplified converter that handles basic HTML elements
         and converts them to corresponding ADF structures.
         """
         from bs4 import BeautifulSoup
 
         try:
-            soup = BeautifulSoup(html, 'html.parser')
+            soup = BeautifulSoup(html, "html.parser")
             content = []
 
             # Process each top-level element
             for element in soup.children:
-                if hasattr(element, 'name') and element.name:
+                if hasattr(element, "name") and element.name:
                     adf_node = self._convert_html_element_to_adf(element)
                     if adf_node:
                         content.append(adf_node)
-                elif hasattr(element, 'strip') and element.strip():  # Text node
+                elif hasattr(element, "strip") and element.strip():  # Text node
                     # Wrap loose text in paragraph
-                    content.append({
-                        "type": "paragraph",
-                        "content": [{"type": "text", "text": element.strip()}]
-                    })
+                    content.append(
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": element.strip()}],
+                        }
+                    )
 
             return content if content else [self._create_empty_paragraph()]
 
@@ -240,23 +231,23 @@ class ADFGenerator:
 
     def _convert_html_element_to_adf(self, element: Any) -> dict[str, Any] | None:
         """Convert a single HTML element to ADF node."""
-        if not hasattr(element, 'name') or not element.name:
+        if not hasattr(element, "name") or not element.name:
             return None
         tag_name = element.name.lower()
 
-        if tag_name in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']:
+        if tag_name in ["h1", "h2", "h3", "h4", "h5", "h6"]:
             return self._convert_heading(element)
-        elif tag_name == 'p':
+        elif tag_name == "p":
             return self._convert_paragraph(element)
-        elif tag_name in ['ul', 'ol']:
+        elif tag_name in ["ul", "ol"]:
             return self._convert_list(element)
-        elif tag_name == 'pre':
+        elif tag_name == "pre":
             return self._convert_code_block(element)
-        elif tag_name == 'blockquote':
+        elif tag_name == "blockquote":
             return self._convert_blockquote(element)
-        elif tag_name == 'table':
+        elif tag_name == "table":
             return self._convert_table(element)
-        elif tag_name == 'hr':
+        elif tag_name == "hr":
             return self._convert_rule()
         else:
             # For unhandled elements, try to extract text content
@@ -264,7 +255,7 @@ class ADFGenerator:
             if text_content:
                 return {
                     "type": "paragraph",
-                    "content": [{"type": "text", "text": text_content}]
+                    "content": [{"type": "text", "text": text_content}],
                 }
         return None
 
@@ -275,7 +266,7 @@ class ADFGenerator:
         return {
             "type": "heading",
             "attrs": {"level": level},
-            "content": self._convert_inline_content(element)
+            "content": self._convert_inline_content(element),
         }
 
     def _convert_paragraph(self, element: Any) -> dict[str, Any]:
@@ -286,10 +277,7 @@ class ADFGenerator:
         if not content:
             return self._create_empty_paragraph()
 
-        return {
-            "type": "paragraph",
-            "content": content
-        }
+        return {"type": "paragraph", "content": content}
 
     def _convert_list(self, element: Any, nesting_level: int = 0) -> dict[str, Any]:
         """Convert list element to ADF bulletList or orderedList with lazy evaluation."""
@@ -299,43 +287,57 @@ class ADFGenerator:
         content = []
         item_count = 0
 
-        for li in element.find_all('li', recursive=False):
+        for li in element.find_all("li", recursive=False):
             if item_count >= max_items:
                 # Add truncation notice for very large lists
-                content.append({
-                    "type": "listItem",
-                    "content": [{
-                        "type": "paragraph",
-                        "content": [{"type": "text", "text": f"... (list truncated after {max_items} items for performance)"}]
-                    }]
-                })
+                content.append(
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": f"... (list truncated after {max_items} items for performance)",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                )
                 break
 
             list_item_content = self._convert_list_item_content(li, nesting_level)
             if list_item_content:
-                content.append({
-                    "type": "listItem",
-                    "content": list_item_content
-                })
+                content.append({"type": "listItem", "content": list_item_content})
             item_count += 1
 
-        return {
-            "type": list_type,
-            "content": content
-        }
+        return {"type": list_type, "content": content}
 
-    def _convert_list_item_content(self, li_element: Any, nesting_level: int = 0) -> list[dict[str, Any]]:
+    def _convert_list_item_content(
+        self, li_element: Any, nesting_level: int = 0
+    ) -> list[dict[str, Any]]:
         """Convert list item content to ADF format with lazy evaluation for deep nesting."""
         content = []
         max_nesting = 10  # Prevent excessive nesting for performance
 
         # Prevent infinite recursion and excessive nesting
         if nesting_level > max_nesting:
-            logger.warning(f"List nesting exceeded maximum depth ({max_nesting}), truncating")
-            return [{
-                "type": "paragraph",
-                "content": [{"type": "text", "text": f"... (nesting too deep, truncated at level {max_nesting})"}]
-            }]
+            logger.warning(
+                f"List nesting exceeded maximum depth ({max_nesting}), truncating"
+            )
+            return [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": f"... (nesting too deep, truncated at level {max_nesting})",
+                        }
+                    ],
+                }
+            ]
 
         # Handle nested elements in list item with lazy evaluation
         child_count = 0
@@ -343,25 +345,29 @@ class ADFGenerator:
 
         for child in li_element.children:
             if child_count >= max_children:
-                content.append({
-                    "type": "paragraph",
-                    "content": [{"type": "text", "text": f"... (list item truncated after {max_children} children)"}]
-                })
+                content.append(
+                    {
+                        "type": "paragraph",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": f"... (list item truncated after {max_children} children)",
+                            }
+                        ],
+                    }
+                )
                 break
 
-            if hasattr(child, 'name'):
-                if child.name in ['ul', 'ol']:
+            if hasattr(child, "name"):
+                if child.name in ["ul", "ol"]:
                     # Nested list - use lazy evaluation
                     nested_list = self._convert_list(child, nesting_level + 1)
                     content.append(nested_list)
-                elif child.name == 'p':
+                elif child.name == "p":
                     # Paragraph in list item
                     para_content = self._convert_inline_content(child)
                     if para_content:
-                        content.append({
-                            "type": "paragraph",
-                            "content": para_content
-                        })
+                        content.append({"type": "paragraph", "content": para_content})
                 else:
                     # Other elements - treat as paragraph
                     text = child.get_text(strip=True)
@@ -369,19 +375,20 @@ class ADFGenerator:
                         # Limit text length for performance
                         if len(text) > 1000:
                             text = text[:997] + "..."
-                        content.append({
-                            "type": "paragraph",
-                            "content": [{"type": "text", "text": text}]
-                        })
+                        content.append(
+                            {
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": text}],
+                            }
+                        )
             elif child.strip():
                 # Direct text content
                 text = child.strip()
                 if len(text) > 1000:
                     text = text[:997] + "..."
-                content.append({
-                    "type": "paragraph",
-                    "content": [{"type": "text", "text": text}]
-                })
+                content.append(
+                    {"type": "paragraph", "content": [{"type": "text", "text": text}]}
+                )
 
             child_count += 1
 
@@ -390,140 +397,143 @@ class ADFGenerator:
 
     def _convert_code_block(self, element: Any) -> dict[str, Any]:
         """Convert code block to ADF codeBlock."""
-        code_element = element.find('code')
+        code_element = element.find("code")
         if code_element:
-            code_text = code_element.get_text().rstrip('\n')
+            code_text = code_element.get_text().rstrip("\n")
 
             # Try to extract language from class
             language = None
-            if code_element.get('class'):
-                for cls in code_element.get('class'):
-                    if cls.startswith('language-'):
-                        language = cls.replace('language-', '')
+            if code_element.get("class"):
+                for cls in code_element.get("class"):
+                    if cls.startswith("language-"):
+                        language = cls.replace("language-", "")
                         break
 
             attrs = {}
             if language:
-                attrs['language'] = language
+                attrs["language"] = language
 
             return {
                 "type": "codeBlock",
                 "attrs": attrs,
-                "content": [
-                    {
-                        "type": "text",
-                        "text": code_text
-                    }
-                ]
+                "content": [{"type": "text", "text": code_text}],
             }
         else:
             # Fallback to plain text
             return {
                 "type": "codeBlock",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": element.get_text().rstrip('\n')
-                    }
-                ]
+                "content": [{"type": "text", "text": element.get_text().rstrip("\n")}],
             }
 
     def _convert_blockquote(self, element: Any) -> dict[str, Any]:
         """Convert blockquote to ADF blockquote."""
         content = []
 
-        for child in element.find_all(['p', 'div'], recursive=False):
+        for child in element.find_all(["p", "div"], recursive=False):
             para_content = self._convert_inline_content(child)
             if para_content:
-                content.append({
-                    "type": "paragraph",
-                    "content": para_content
-                })
+                content.append({"type": "paragraph", "content": para_content})
 
         if not content:
             # Fallback to text content
             text = element.get_text(strip=True)
             if text:
-                content = [{
-                    "type": "paragraph",
-                    "content": [{"type": "text", "text": text}]
-                }]
+                content = [
+                    {"type": "paragraph", "content": [{"type": "text", "text": text}]}
+                ]
 
         return {
             "type": "blockquote",
-            "content": content if content else [self._create_empty_paragraph()]
+            "content": content if content else [self._create_empty_paragraph()],
         }
 
     def _convert_table(self, element: Any) -> dict[str, Any]:
         """Convert table to ADF table with lazy evaluation for performance."""
         # Use lazy evaluation for large tables to improve performance
 
-        def lazy_convert_rows():
+        def lazy_convert_rows() -> list[dict[str, Any]]:
             """Lazily convert table rows to avoid processing large tables upfront."""
-            rows = []
+            rows: list[dict[str, Any]] = []
             row_count = 0
             max_rows = self.max_table_rows  # Limit large tables for performance
 
-            for tr in element.find_all('tr'):
+            for tr in element.find_all("tr"):
                 if row_count >= max_rows:
                     # Add truncation notice for very large tables
-                    rows.append({
-                        "type": "tableRow",
-                        "content": [{
-                            "type": "tableCell",
-                            "content": [{
-                                "type": "paragraph",
-                                "content": [{"type": "text", "text": f"... table truncated after {max_rows} rows for performance"}]
-                            }]
-                        }]
-                    })
+                    rows.append(
+                        {
+                            "type": "tableRow",
+                            "content": [
+                                {
+                                    "type": "tableCell",
+                                    "content": [
+                                        {
+                                            "type": "paragraph",
+                                            "content": [
+                                                {
+                                                    "type": "text",
+                                                    "text": f"... table truncated after {max_rows} rows for performance",
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    )
                     break
 
                 cells = []
                 cell_count = 0
                 max_cells = 20  # Limit cells per row
 
-                for cell in tr.find_all(['td', 'th']):
+                for cell in tr.find_all(["td", "th"]):
                     if cell_count >= max_cells:
                         # Determine cell type based on tag
-                        cell_type = "tableHeader" if cell.name == 'th' else "tableCell"
-                        cells.append({
-                            "type": cell_type,
-                            "content": [{
-                                "type": "paragraph",
-                                "content": [{"type": "text", "text": "... (truncated)"}]
-                            }]
-                        })
+                        cell_type = "tableHeader" if cell.name == "th" else "tableCell"
+                        cells.append(
+                            {
+                                "type": cell_type,
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [
+                                            {"type": "text", "text": "... (truncated)"}
+                                        ],
+                                    }
+                                ],
+                            }
+                        )
                         break
 
                     # Lazy content conversion - only process when needed
                     cell_content = self._convert_inline_content(cell)
-                    
+
                     # Determine cell type based on tag - th for headers, td for regular cells
-                    cell_type = "tableHeader" if cell.name == 'th' else "tableCell"
-                    
-                    cells.append({
-                        "type": cell_type,
-                        "content": [{
-                            "type": "paragraph",
-                            "content": cell_content if cell_content else [{"type": "text", "text": ""}]
-                        }]
-                    })
+                    cell_type = "tableHeader" if cell.name == "th" else "tableCell"
+
+                    cells.append(
+                        {
+                            "type": cell_type,
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": cell_content
+                                    if cell_content
+                                    else [{"type": "text", "text": ""}],
+                                }
+                            ],
+                        }
+                    )
                     cell_count += 1
 
                 if cells:
-                    rows.append({
-                        "type": "tableRow",
-                        "content": cells
-                    })
+                    rows.append({"type": "tableRow", "content": cells})
                 row_count += 1
 
             return rows
 
-        return {
-            "type": "table",
-            "content": lazy_convert_rows()
-        }
+        return {"type": "table", "content": lazy_convert_rows()}
 
     def _convert_rule(self) -> dict[str, Any]:
         """Convert horizontal rule to ADF rule."""
@@ -535,22 +545,23 @@ class ADFGenerator:
 
         # Handle direct text and inline formatting
         for child in element.children:
-            if hasattr(child, 'name') and child.name:  # Check that name is not None
+            if hasattr(child, "name") and child.name:  # Check that name is not None
                 adf_inline = self._convert_inline_element(child)
                 if adf_inline:
-                    content.extend(adf_inline if isinstance(adf_inline, list) else [adf_inline])
-            elif hasattr(child, 'strip') and child.strip():
+                    content.extend(
+                        adf_inline if isinstance(adf_inline, list) else [adf_inline]
+                    )
+            elif hasattr(child, "strip") and child.strip():
                 # Direct text node (NavigableString)
-                content.append({
-                    "type": "text",
-                    "text": child.strip()
-                })
+                content.append({"type": "text", "text": child.strip()})
 
         return content
 
-    def _convert_inline_element(self, element: Any) -> dict[str, Any] | list[dict[str, Any]] | None:
+    def _convert_inline_element(
+        self, element: Any
+    ) -> dict[str, Any] | list[dict[str, Any]] | None:
         """Convert inline HTML element to ADF inline node."""
-        if not hasattr(element, 'name') or element.name is None:
+        if not hasattr(element, "name") or element.name is None:
             return None
         tag_name = element.name.lower()
         text_content = element.get_text()
@@ -561,51 +572,44 @@ class ADFGenerator:
         # Basic text formatting
         marks: list[dict[str, Any]] = []
 
-        if tag_name in ['strong', 'b']:
+        if tag_name in ["strong", "b"]:
             marks.append({"type": "strong"})
-        elif tag_name in ['em', 'i']:
+        elif tag_name in ["em", "i"]:
             marks.append({"type": "em"})
-        elif tag_name == 'code':
+        elif tag_name == "code":
             marks.append({"type": "code"})
-        elif tag_name in ['s', 'del', 'strike']:
+        elif tag_name in ["s", "del", "strike"]:
             marks.append({"type": "strike"})
-        elif tag_name == 'u':
+        elif tag_name == "u":
             marks.append({"type": "underline"})
-        elif tag_name == 'a':
-            href = element.get('href')
+        elif tag_name == "a":
+            href = element.get("href")
             if href:
-                marks.append({
-                    "type": "link", 
-                    "attrs": {"href": href}
-                })
+                marks.append({"type": "link", "attrs": {"href": href}})
 
         # For nested formatting, we need to handle child elements
-        if element.children and any(hasattr(child, 'name') and child.name for child in element.children):
+        if element.children and any(
+            hasattr(child, "name") and child.name for child in element.children
+        ):
             # Has nested elements - process recursively
             nested_content = []
             for child in element.children:
-                if hasattr(child, 'name') and child.name:
+                if hasattr(child, "name") and child.name:
                     child_content = self._convert_inline_element(child)
                     if child_content:
                         if isinstance(child_content, list):
                             nested_content.extend(child_content)
                         else:
                             nested_content.append(child_content)
-                elif hasattr(child, 'strip') and child.strip():
-                    text_node = {
-                        "type": "text",
-                        "text": child.strip()
-                    }
+                elif hasattr(child, "strip") and child.strip():
+                    text_node = {"type": "text", "text": child.strip()}
                     if marks:
                         text_node["marks"] = marks
                     nested_content.append(text_node)
             return nested_content
         else:
             # Simple text with marks
-            text_node = {
-                "type": "text",
-                "text": text_content
-            }
+            text_node = {"type": "text", "text": text_content}
             if marks:
                 text_node["marks"] = marks
 
@@ -613,30 +617,19 @@ class ADFGenerator:
 
     def _create_empty_paragraph(self) -> dict[str, Any]:
         """Create an empty ADF paragraph."""
-        return {
-            "type": "paragraph",
-            "content": []
-        }
+        return {"type": "paragraph", "content": []}
 
     def _create_plain_text_paragraph(self, text: str) -> dict[str, Any]:
         """Create ADF paragraph with plain text."""
-        return {
-            "type": "paragraph",
-            "content": [
-                {
-                    "type": "text",
-                    "text": text
-                }
-            ]
-        }
+        return {"type": "paragraph", "content": [{"type": "text", "text": text}]}
 
     def validate_adf(self, adf_json: dict[str, Any]) -> bool:
         """
         Validate ADF JSON structure (basic validation).
-        
+
         Args:
             adf_json: ADF JSON to validate
-            
+
         Returns:
             True if valid, False otherwise
         """
@@ -666,13 +659,15 @@ class ADFGenerator:
             logger.error(f"ADF validation error: {e}")
             return False
 
-    def _create_error_adf(self, original_markdown: str, error_message: str) -> dict[str, Any]:
+    def _create_error_adf(
+        self, original_markdown: str, error_message: str
+    ) -> dict[str, Any]:
         """Create a graceful fallback ADF document when conversion fails.
-        
+
         Args:
             original_markdown: The original markdown that failed to convert
             error_message: The error message from the failed conversion
-            
+
         Returns:
             ADF document with error information and original text
         """
@@ -681,7 +676,12 @@ class ADFGenerator:
         # Try to preserve at least the original text content
         try:
             # Remove markdown formatting and use as plain text
-            plain_text = original_markdown.replace('*', '').replace('_', '').replace('#', '').strip()
+            plain_text = (
+                original_markdown.replace("*", "")
+                .replace("_", "")
+                .replace("#", "")
+                .strip()
+            )
 
             # Limit text length to prevent oversized documents
             if len(plain_text) > 1000:
@@ -694,13 +694,10 @@ class ADFGenerator:
                     {
                         "type": "paragraph",
                         "content": [
-                            {
-                                "type": "text",
-                                "text": f"[Conversion Error] {plain_text}"
-                            }
-                        ]
+                            {"type": "text", "text": f"[Conversion Error] {plain_text}"}
+                        ],
                     }
-                ]
+                ],
             }
         except Exception as fallback_error:
             # Ultimate fallback - minimal valid ADF
@@ -714,49 +711,66 @@ class ADFGenerator:
                         "content": [
                             {
                                 "type": "text",
-                                "text": "[Conversion Failed - Unable to Process Content]"
+                                "text": "[Conversion Failed - Unable to Process Content]",
                             }
-                        ]
+                        ],
                     }
-                ]
+                ],
             }
 
     def get_performance_metrics(self) -> dict[str, Any]:
         """Get performance metrics for monitoring and optimization.
-        
+
         Returns:
             Dictionary containing performance statistics
         """
-        cache_info = self._cached_convert.cache_info() if hasattr(self._cached_convert, 'cache_info') else None
+        cache_info = (
+            self._cached_convert.cache_info()
+            if hasattr(self._cached_convert, "cache_info")
+            else None
+        )
 
         metrics = self.metrics.copy()
-        metrics.update({
-            'cache_hit_rate': (self.metrics['conversions_cached'] / max(1, self.metrics['conversions_total'])) * 100,
-            'average_conversion_time': self.metrics['conversion_time_total'] / max(1, self.metrics['conversions_total']),
-            'error_rate': (self.metrics['conversion_errors'] / max(1, self.metrics['conversions_total'])) * 100,
-            'cache_info': {
-                'hits': cache_info.hits if cache_info else 0,
-                'misses': cache_info.misses if cache_info else 0,
-                'maxsize': cache_info.maxsize if cache_info else 0,
-                'currsize': cache_info.currsize if cache_info else 0
-            } if cache_info else None
-        })
+        metrics.update(
+            {
+                "cache_hit_rate": (
+                    self.metrics["conversions_cached"]
+                    / max(1, self.metrics["conversions_total"])
+                )
+                * 100,
+                "average_conversion_time": self.metrics["conversion_time_total"]
+                / max(1, self.metrics["conversions_total"]),
+                "error_rate": (
+                    self.metrics["conversion_errors"]
+                    / max(1, self.metrics["conversions_total"])
+                )
+                * 100,
+                "cache_info": {
+                    "hits": cache_info.hits if cache_info else 0,
+                    "misses": cache_info.misses if cache_info else 0,
+                    "maxsize": cache_info.maxsize if cache_info else 0,
+                    "currsize": cache_info.currsize if cache_info else 0,
+                }
+                if cache_info
+                else None,
+            }
+        )
 
         return metrics
 
     def clear_cache(self) -> None:
         """Clear the conversion cache to free memory."""
-        if hasattr(self._cached_convert, 'cache_clear'):
+        if hasattr(self._cached_convert, "cache_clear"):
             self._cached_convert.cache_clear()
             logger.info("ADF conversion cache cleared")
 
     def reset_metrics(self) -> None:
         """Reset performance metrics counters."""
         self.metrics = {
-            'conversions_total': 0,
-            'conversions_cached': 0,
-            'conversion_time_total': 0.0,
-            'conversion_errors': 0,
-            'last_error': None
+            "conversions_total": 0,
+            "conversions_cached": 0,
+            "conversion_time_total": 0.0,
+            "conversion_errors": 0,
+            "last_error": None,
         }
         logger.info("ADF performance metrics reset")

--- a/src/mcp_atlassian/formatting/adf_enhanced.py
+++ b/src/mcp_atlassian/formatting/adf_enhanced.py
@@ -9,19 +9,14 @@ import logging
 import re
 import time
 from functools import lru_cache
-from typing import Any, Optional
-
-import markdown
-from markdown import BlockParser, InlineProcessor
-from markdown.extensions import Extension
-from markdown.treebuilders import etree
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
 class DirectADFGenerator:
     """Enhanced ADF generator with direct markdown-to-ADF conversion.
-    
+
     Key improvements:
     - Direct conversion without HTML intermediate
     - Support for panels, expand/collapse, and media
@@ -31,37 +26,37 @@ class DirectADFGenerator:
     """
 
     def __init__(
-        self, 
+        self,
         cache_size: int = 256,
         max_table_rows: int = 100,
         max_list_items: int = 200,
-        max_nesting_depth: int = 10
+        max_nesting_depth: int = 10,
     ) -> None:
         """Initialize enhanced ADF generator.
-        
+
         Args:
             cache_size: LRU cache size for conversions
             max_table_rows: Maximum rows before table truncation
-            max_list_items: Maximum items before list truncation  
+            max_list_items: Maximum items before list truncation
             max_nesting_depth: Maximum nesting depth for lists
         """
         self.cache_size = cache_size
         self.max_table_rows = max_table_rows
         self.max_list_items = max_list_items
         self.max_nesting_depth = max_nesting_depth
-        
+
         # Performance metrics
         self.metrics: dict[str, Any] = {
-            'conversions_total': 0,
-            'conversions_cached': 0,
-            'conversion_time_total': 0.0,
-            'conversion_errors': 0,
-            'nodes_created': {}
+            "conversions_total": 0,
+            "conversions_cached": 0,
+            "conversion_time_total": 0.0,
+            "conversion_errors": 0,
+            "nodes_created": {},
         }
-        
+
         # Configure cache
         self._configure_cache(cache_size)
-        
+
         # Compile regex patterns for better performance
         self._compile_patterns()
 
@@ -69,29 +64,20 @@ class DirectADFGenerator:
         """Compile regex patterns for markdown parsing."""
         # Panel detection: {panel:type}content{panel}
         self.panel_pattern = re.compile(
-            r'\{panel:(\w+)\}(.*?)\{panel\}',
-            re.DOTALL | re.MULTILINE
+            r"\{panel:(\w+)\}(.*?)\{panel\}", re.DOTALL | re.MULTILINE
         )
-        
+
         # Status detection: {status:color}text{status}
-        self.status_pattern = re.compile(
-            r'\{status:(\w+)\}(.*?)\{status\}'
-        )
-        
+        self.status_pattern = re.compile(r"\{status:(\w+)\}(.*?)\{status\}")
+
         # Mention detection: @[User Name]
-        self.mention_pattern = re.compile(
-            r'@\[([^\]]+)\]'
-        )
-        
+        self.mention_pattern = re.compile(r"@\[([^\]]+)\]")
+
         # Date detection: {date:YYYY-MM-DD}
-        self.date_pattern = re.compile(
-            r'\{date:(\d{4}-\d{2}-\d{2})\}'
-        )
-        
+        self.date_pattern = re.compile(r"\{date:(\d{4}-\d{2}-\d{2})\}")
+
         # Emoji detection: :emoji_name:
-        self.emoji_pattern = re.compile(
-            r':([a-zA-Z0-9_+-]+):'
-        )
+        self.emoji_pattern = re.compile(r":([a-zA-Z0-9_+-]+):")
 
     def _configure_cache(self, cache_size: int) -> None:
         """Configure LRU cache for conversions."""
@@ -101,255 +87,254 @@ class DirectADFGenerator:
 
     def markdown_to_adf(self, markdown_text: str) -> dict[str, Any]:
         """Convert markdown to ADF with caching.
-        
+
         Args:
             markdown_text: Input markdown text
-            
+
         Returns:
             ADF document structure
         """
         start_time = time.time()
-        self.metrics['conversions_total'] += 1
-        
+        self.metrics["conversions_total"] += 1
+
         try:
             # Handle empty input
             if not markdown_text or not markdown_text.strip():
                 return self._create_empty_document()
-            
+
             # Create cache key
-            cache_key = hashlib.md5(markdown_text.encode('utf-8')).hexdigest()
-            
+            cache_key = hashlib.sha256(markdown_text.encode("utf-8")).hexdigest()
+
             # Try cached result
             result = self._cached_convert(cache_key, markdown_text)
             if result:
-                self.metrics['conversions_cached'] += 1
-            
+                self.metrics["conversions_cached"] += 1
+
             return result
-            
+
         except Exception as e:
-            self.metrics['conversion_errors'] += 1
+            self.metrics["conversion_errors"] += 1
             logger.error(f"ADF conversion failed: {e}")
             return self._create_error_document(markdown_text, str(e))
-            
+
         finally:
             conversion_time = time.time() - start_time
-            self.metrics['conversion_time_total'] += conversion_time
+            self.metrics["conversion_time_total"] += conversion_time
             if conversion_time > 0.1:
                 logger.warning(
                     f"Slow conversion: {conversion_time:.3f}s for {len(markdown_text)} chars"
                 )
 
     def _convert_markdown_uncached(
-        self, 
-        cache_key: str, 
-        markdown_text: str
+        self, cache_key: str, markdown_text: str
     ) -> dict[str, Any]:
         """Convert markdown to ADF without caching.
-        
+
         This method does direct parsing of markdown patterns to ADF nodes.
         """
         # Pre-process for ADF-specific patterns
         content = self._preprocess_markdown(markdown_text)
-        
+
         # Parse into blocks
         blocks = self._parse_markdown_blocks(content)
-        
+
         # Convert blocks to ADF nodes
         adf_content = []
         for block in blocks:
             node = self._convert_block_to_adf(block)
             if node:
                 adf_content.append(node)
-                self._track_node_metrics(node['type'])
-        
-        return {
-            "version": 1,
-            "type": "doc",
-            "content": adf_content
-        }
+                self._track_node_metrics(node["type"])
+
+        return {"version": 1, "type": "doc", "content": adf_content}
 
     def _preprocess_markdown(self, text: str) -> str:
         """Pre-process markdown for ADF-specific patterns."""
         # Handle panels first to preserve internal content
         text = self._extract_panels(text)
-        
+
         # Handle other ADF-specific patterns
         text = self._extract_status(text)
         text = self._extract_mentions(text)
         text = self._extract_dates(text)
-        
+
         return text
 
     def _extract_panels(self, text: str) -> str:
         """Extract and mark panel blocks."""
-        def panel_replacer(match):
+
+        def panel_replacer(match: re.Match[str]) -> str:
             panel_type = match.group(1)
             content = match.group(2).strip()
             # Mark with special delimiter for later processing
             return f"\n<<<PANEL:{panel_type}>>>\n{content}\n<<<END_PANEL>>>\n"
-        
+
         return self.panel_pattern.sub(panel_replacer, text)
 
     def _extract_status(self, text: str) -> str:
         """Extract and mark status inline elements."""
-        def status_replacer(match):
+
+        def status_replacer(match: re.Match[str]) -> str:
             color = match.group(1)
             status_text = match.group(2)
             return f"<<<STATUS:{color}:{status_text}>>>"
-        
+
         return self.status_pattern.sub(status_replacer, text)
 
     def _extract_mentions(self, text: str) -> str:
         """Extract and mark mention inline elements."""
-        def mention_replacer(match):
+
+        def mention_replacer(match: re.Match[str]) -> str:
             name = match.group(1)
             return f"<<<MENTION:{name}>>>"
-        
+
         return self.mention_pattern.sub(mention_replacer, text)
 
     def _extract_dates(self, text: str) -> str:
         """Extract and mark date inline elements."""
-        def date_replacer(match):
+
+        def date_replacer(match: re.Match[str]) -> str:
             date = match.group(1)
             # Convert to timestamp (simplified)
             return f"<<<DATE:{date}>>>"
-        
+
         return self.date_pattern.sub(date_replacer, text)
 
     def _parse_markdown_blocks(self, text: str) -> list[dict[str, Any]]:
         """Parse markdown into block structures."""
-        blocks = []
-        lines = text.split('\n')
+        blocks: list[dict[str, Any]] = []
+        lines = text.split("\n")
         i = 0
-        
+
         while i < len(lines):
             line = lines[i]
-            
+
             # Check for panel marker
             if line.startswith("<<<PANEL:"):
-                panel_type = line[9:line.index(">>>")]
+                panel_type = line[9 : line.index(">>>")]
                 content_lines = []
                 i += 1
                 while i < len(lines) and not lines[i].startswith("<<<END_PANEL>>>"):
                     content_lines.append(lines[i])
                     i += 1
-                blocks.append({
-                    'type': 'panel',
-                    'panel_type': panel_type,
-                    'content': '\n'.join(content_lines)
-                })
+                blocks.append(
+                    {
+                        "type": "panel",
+                        "panel_type": panel_type,
+                        "content": "\n".join(content_lines),
+                    }
+                )
                 i += 1
                 continue
-            
+
             # Check for headings
-            if line.startswith('#'):
-                level = len(line) - len(line.lstrip('#'))
+            if line.startswith("#"):
+                level = len(line) - len(line.lstrip("#"))
                 if 1 <= level <= 6:
-                    blocks.append({
-                        'type': 'heading',
-                        'level': level,
-                        'content': line.lstrip('#').strip()
-                    })
+                    blocks.append(
+                        {
+                            "type": "heading",
+                            "level": level,
+                            "content": line.lstrip("#").strip(),
+                        }
+                    )
                     i += 1
                     continue
-            
+
             # Check for code blocks
-            if line.startswith('```'):
+            if line.startswith("```"):
                 language = line[3:].strip() or None
                 code_lines = []
                 i += 1
-                while i < len(lines) and not lines[i].startswith('```'):
+                while i < len(lines) and not lines[i].startswith("```"):
                     code_lines.append(lines[i])
                     i += 1
-                blocks.append({
-                    'type': 'codeBlock',
-                    'language': language,
-                    'content': '\n'.join(code_lines)
-                })
+                blocks.append(
+                    {
+                        "type": "codeBlock",
+                        "language": language,
+                        "content": "\n".join(code_lines),
+                    }
+                )
                 i += 1
                 continue
-            
+
             # Check for lists
-            if line.strip().startswith(('- ', '* ', '+ ')):
-                list_block = self._parse_list_block(lines, i, 'bulletList')
+            if line.strip().startswith(("- ", "* ", "+ ")):
+                list_block = self._parse_list_block(lines, i, "bulletList")
                 blocks.append(list_block)
-                i = list_block['end_index']
+                i = list_block["end_index"]
                 continue
-            
+
             # Check for ordered lists
-            if re.match(r'^\d+\.\s', line.strip()):
-                list_block = self._parse_list_block(lines, i, 'orderedList')
+            if re.match(r"^\d+\.\s", line.strip()):
+                list_block = self._parse_list_block(lines, i, "orderedList")
                 blocks.append(list_block)
-                i = list_block['end_index']
+                i = list_block["end_index"]
                 continue
-            
+
             # Check for blockquote
-            if line.startswith('>'):
+            if line.startswith(">"):
                 quote_lines = []
-                while i < len(lines) and lines[i].startswith('>'):
+                while i < len(lines) and lines[i].startswith(">"):
                     quote_lines.append(lines[i][1:].strip())
                     i += 1
-                blocks.append({
-                    'type': 'blockquote',
-                    'content': '\n'.join(quote_lines)
-                })
+                blocks.append({"type": "blockquote", "content": "\n".join(quote_lines)})
                 continue
-            
+
             # Check for horizontal rule
-            if line.strip() in ['---', '***', '___'] and len(line.strip()) >= 3:
-                blocks.append({'type': 'rule'})
+            if line.strip() in ["---", "***", "___"] and len(line.strip()) >= 3:
+                blocks.append({"type": "rule"})
                 i += 1
                 continue
-            
+
             # Check for table
-            if i + 1 < len(lines) and '|' in line and '|' in lines[i + 1]:
+            if i + 1 < len(lines) and "|" in line and "|" in lines[i + 1]:
                 table_block = self._parse_table_block(lines, i)
                 if table_block:
                     blocks.append(table_block)
-                    i = table_block['end_index']
+                    i = table_block["end_index"]
                     continue
-            
+
             # Default: paragraph
             if line.strip():
                 para_lines = [line]
                 i += 1
-                while i < len(lines) and lines[i].strip() and not self._is_block_start(lines[i]):
+                while (
+                    i < len(lines)
+                    and lines[i].strip()
+                    and not self._is_block_start(lines[i])
+                ):
                     para_lines.append(lines[i])
                     i += 1
-                blocks.append({
-                    'type': 'paragraph',
-                    'content': '\n'.join(para_lines)
-                })
+                blocks.append({"type": "paragraph", "content": "\n".join(para_lines)})
             else:
                 i += 1
-        
+
         return blocks
 
     def _is_block_start(self, line: str) -> bool:
         """Check if line starts a new block element."""
         line = line.strip()
         return (
-            line.startswith('#') or
-            line.startswith('```') or
-            line.startswith(('- ', '* ', '+ ')) or
-            re.match(r'^\d+\.\s', line) or
-            line.startswith('>') or
-            line in ['---', '***', '___'] or
-            '|' in line or
-            line.startswith("<<<PANEL:")
+            line.startswith("#")
+            or line.startswith("```")
+            or line.startswith(("- ", "* ", "+ "))
+            or re.match(r"^\d+\.\s", line)
+            or line.startswith(">")
+            or line in ["---", "***", "___"]
+            or "|" in line
+            or line.startswith("<<<PANEL:")
         )
 
     def _parse_list_block(
-        self, 
-        lines: list[str], 
-        start_index: int, 
-        list_type: str
+        self, lines: list[str], start_index: int, list_type: str
     ) -> dict[str, Any]:
         """Parse a list block with proper nesting."""
         items = []
         i = start_index
         current_indent = 0
-        
+
         while i < len(lines):
             line = lines[i]
             if not line.strip():
@@ -359,106 +344,92 @@ class DirectADFGenerator:
                     continue
                 else:
                     break
-            
+
             # Check if it's a list item
             indent = len(line) - len(line.lstrip())
             if self._is_list_item(line.lstrip()):
                 # Extract item content
-                if list_type == 'bulletList':
-                    content = re.sub(r'^[-*+]\s+', '', line.lstrip())
+                if list_type == "bulletList":
+                    content = re.sub(r"^[-*+]\s+", "", line.lstrip())
                 else:
-                    content = re.sub(r'^\d+\.\s+', '', line.lstrip())
-                
-                items.append({
-                    'indent': indent,
-                    'content': content,
-                    'children': []
-                })
+                    content = re.sub(r"^\d+\.\s+", "", line.lstrip())
+
+                items.append({"indent": indent, "content": content, "children": []})
                 i += 1
             else:
                 # Not a list item, end of list
                 break
-        
-        return {
-            'type': list_type,
-            'items': items,
-            'end_index': i
-        }
+
+        return {"type": list_type, "items": items, "end_index": i}
 
     def _is_list_item(self, line: str) -> bool:
         """Check if line is a list item."""
         line = line.strip()
         return (
-            line.startswith(('- ', '* ', '+ ')) or
-            re.match(r'^\d+\.\s', line) is not None
+            line.startswith(("- ", "* ", "+ "))
+            or re.match(r"^\d+\.\s", line) is not None
         )
 
-    def _parse_table_block(self, lines: list[str], start_index: int) -> dict[str, Any] | None:
+    def _parse_table_block(
+        self, lines: list[str], start_index: int
+    ) -> dict[str, Any] | None:
         """Parse a markdown table."""
-        if '|' not in lines[start_index]:
+        if "|" not in lines[start_index]:
             return None
-        
+
         rows = []
         i = start_index
         has_header = False
-        
+
         # Parse rows
-        while i < len(lines) and '|' in lines[i]:
-            cells = [cell.strip() for cell in lines[i].split('|')[1:-1]]
+        while i < len(lines) and "|" in lines[i]:
+            cells = [cell.strip() for cell in lines[i].split("|")[1:-1]]
             if cells:
                 rows.append(cells)
             i += 1
-            
+
             # Check for separator row (indicates header)
-            if i < len(lines) and re.match(r'^[\s|:-]+$', lines[i]):
+            if i < len(lines) and re.match(r"^[\s|:-]+$", lines[i]):
                 has_header = True
                 i += 1
-        
+
         if not rows:
             return None
-        
-        return {
-            'type': 'table',
-            'rows': rows,
-            'has_header': has_header,
-            'end_index': i
-        }
+
+        return {"type": "table", "rows": rows, "has_header": has_header, "end_index": i}
 
     def _convert_block_to_adf(self, block: dict[str, Any]) -> dict[str, Any] | None:
         """Convert a parsed block to ADF node."""
-        block_type = block['type']
-        
-        if block_type == 'heading':
+        block_type = block["type"]
+
+        if block_type == "heading":
             return {
                 "type": "heading",
-                "attrs": {"level": block['level']},
-                "content": self._parse_inline_content(block['content'])
+                "attrs": {"level": block["level"]},
+                "content": self._parse_inline_content(block["content"]),
             }
-        
-        elif block_type == 'paragraph':
-            content = self._parse_inline_content(block['content'])
+
+        elif block_type == "paragraph":
+            content = self._parse_inline_content(block["content"])
             if content:
-                return {
-                    "type": "paragraph",
-                    "content": content
-                }
-        
-        elif block_type == 'codeBlock':
+                return {"type": "paragraph", "content": content}
+
+        elif block_type == "codeBlock":
             attrs = {}
-            if block.get('language'):
-                attrs['language'] = block['language']
+            if block.get("language"):
+                attrs["language"] = block["language"]
             return {
                 "type": "codeBlock",
                 "attrs": attrs,
-                "content": [{"type": "text", "text": block['content']}]
+                "content": [{"type": "text", "text": block["content"]}],
             }
-        
-        elif block_type in ['bulletList', 'orderedList']:
+
+        elif block_type in ["bulletList", "orderedList"]:
             return self._convert_list_to_adf(block)
-        
-        elif block_type == 'blockquote':
+
+        elif block_type == "blockquote":
             # Parse content as nested blocks
-            nested_blocks = self._parse_markdown_blocks(block['content'])
+            nested_blocks = self._parse_markdown_blocks(block["content"])
             content = []
             for nested in nested_blocks:
                 node = self._convert_block_to_adf(nested)
@@ -466,346 +437,355 @@ class DirectADFGenerator:
                     content.append(node)
             return {
                 "type": "blockquote",
-                "content": content if content else [{"type": "paragraph", "content": []}]
+                "content": content
+                if content
+                else [{"type": "paragraph", "content": []}],
             }
-        
-        elif block_type == 'rule':
+
+        elif block_type == "rule":
             return {"type": "rule"}
-        
-        elif block_type == 'table':
+
+        elif block_type == "table":
             return self._convert_table_to_adf(block)
-        
-        elif block_type == 'panel':
+
+        elif block_type == "panel":
             return self._convert_panel_to_adf(block)
-        
+
         return None
 
     def _convert_list_to_adf(self, list_block: dict[str, Any]) -> dict[str, Any]:
         """Convert list block to ADF format."""
-        list_type = list_block['type']
+        list_type = list_block["type"]
         items = []
-        
-        for idx, item in enumerate(list_block['items']):
+
+        for idx, item in enumerate(list_block["items"]):
             if idx >= self.max_list_items:
                 # Add truncation notice
-                items.append({
-                    "type": "listItem",
-                    "content": [{
-                        "type": "paragraph",
-                        "content": [{
-                            "type": "text",
-                            "text": f"... (list truncated after {self.max_list_items} items)"
-                        }]
-                    }]
-                })
+                items.append(
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": f"... (list truncated after {self.max_list_items} items)",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                )
                 break
-            
-            item_content = [{
-                "type": "paragraph",
-                "content": self._parse_inline_content(item['content'])
-            }]
-            
-            items.append({
-                "type": "listItem",
-                "content": item_content
-            })
-        
-        return {
-            "type": list_type,
-            "content": items
-        }
+
+            item_content = [
+                {
+                    "type": "paragraph",
+                    "content": self._parse_inline_content(item["content"]),
+                }
+            ]
+
+            items.append({"type": "listItem", "content": item_content})
+
+        return {"type": list_type, "content": items}
 
     def _convert_table_to_adf(self, table_block: dict[str, Any]) -> dict[str, Any]:
         """Convert table block to ADF format with proper header detection."""
         rows = []
-        has_header = table_block.get('has_header', False)
-        
-        for idx, row_cells in enumerate(table_block['rows']):
+        has_header = table_block.get("has_header", False)
+
+        for idx, row_cells in enumerate(table_block["rows"]):
             if idx >= self.max_table_rows:
                 # Add truncation row
-                rows.append({
-                    "type": "tableRow",
-                    "content": [{
-                        "type": "tableCell",
-                        "content": [{
-                            "type": "paragraph",
-                            "content": [{
-                                "type": "text",
-                                "text": f"... (table truncated after {self.max_table_rows} rows)"
-                            }]
-                        }]
-                    }]
-                })
+                rows.append(
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {
+                                "type": "tableCell",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [
+                                            {
+                                                "type": "text",
+                                                "text": f"... (table truncated after {self.max_table_rows} rows)",
+                                            }
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                )
                 break
-            
+
             cells = []
             for cell_text in row_cells:
                 # Use tableHeader for first row if has_header is True
                 cell_type = "tableHeader" if has_header and idx == 0 else "tableCell"
-                cells.append({
-                    "type": cell_type,
-                    "content": [{
-                        "type": "paragraph",
-                        "content": self._parse_inline_content(cell_text)
-                    }]
-                })
-            
-            rows.append({
-                "type": "tableRow",
-                "content": cells
-            })
-        
+                cells.append(
+                    {
+                        "type": cell_type,
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": self._parse_inline_content(cell_text),
+                            }
+                        ],
+                    }
+                )
+
+            rows.append({"type": "tableRow", "content": cells})
+
         return {
             "type": "table",
-            "attrs": {
-                "isNumberColumnEnabled": False,
-                "layout": "default"
-            },
-            "content": rows
+            "attrs": {"isNumberColumnEnabled": False, "layout": "default"},
+            "content": rows,
         }
 
     def _convert_panel_to_adf(self, block: dict[str, Any]) -> dict[str, Any]:
         """Convert panel block to ADF format."""
-        panel_type = block['panel_type'].lower()
-        if panel_type not in ['info', 'note', 'warning', 'success', 'error']:
-            panel_type = 'info'  # Default
-        
+        panel_type = block["panel_type"].lower()
+        if panel_type not in ["info", "note", "warning", "success", "error"]:
+            panel_type = "info"  # Default
+
         # Parse panel content
-        nested_blocks = self._parse_markdown_blocks(block['content'])
+        nested_blocks = self._parse_markdown_blocks(block["content"])
         content = []
         for nested in nested_blocks:
             node = self._convert_block_to_adf(nested)
             if node:
                 content.append(node)
-        
+
         return {
             "type": "panel",
             "attrs": {"panelType": panel_type},
-            "content": content if content else [{"type": "paragraph", "content": []}]
+            "content": content if content else [{"type": "paragraph", "content": []}],
         }
 
     def _parse_inline_content(self, text: str) -> list[dict[str, Any]]:
         """Parse inline content with formatting and special elements."""
         if not text:
             return []
-        
-        nodes = []
-        
+
+        nodes: list[dict[str, Any]] = []
+
         # Handle special inline patterns
         parts = self._split_inline_patterns(text)
-        
+
         for part in parts:
             if part.startswith("<<<STATUS:"):
                 # Extract status info
-                match = re.match(r'<<<STATUS:(\w+):(.+?)>>>', part)
+                match = re.match(r"<<<STATUS:(\w+):(.+?)>>>", part)
                 if match:
                     color, status_text = match.groups()
-                    nodes.append({
-                        "type": "status",
-                        "attrs": {
-                            "text": status_text,
-                            "color": self._normalize_status_color(color)
+                    nodes.append(
+                        {
+                            "type": "status",
+                            "attrs": {
+                                "text": status_text,
+                                "color": self._normalize_status_color(color),
+                            },
                         }
-                    })
+                    )
             elif part.startswith("<<<MENTION:"):
                 # Extract mention info
-                match = re.match(r'<<<MENTION:(.+?)>>>', part)
+                match = re.match(r"<<<MENTION:(.+?)>>>", part)
                 if match:
                     name = match.group(1)
-                    nodes.append({
-                        "type": "mention",
-                        "attrs": {
-                            "text": f"@{name}",
-                            "id": "unknown"  # Would need user lookup
+                    nodes.append(
+                        {
+                            "type": "mention",
+                            "attrs": {
+                                "text": f"@{name}",
+                                "id": "unknown",  # Would need user lookup
+                            },
                         }
-                    })
+                    )
             elif part.startswith("<<<DATE:"):
                 # Extract date info
-                match = re.match(r'<<<DATE:(.+?)>>>', part)
+                match = re.match(r"<<<DATE:(.+?)>>>", part)
                 if match:
                     date_str = match.group(1)
                     # Convert to timestamp (simplified)
-                    nodes.append({
-                        "type": "date",
-                        "attrs": {
-                            "timestamp": date_str
-                        }
-                    })
+                    nodes.append({"type": "date", "attrs": {"timestamp": date_str}})
             else:
                 # Regular text with markdown formatting
                 formatted_nodes = self._parse_markdown_formatting(part)
                 nodes.extend(formatted_nodes)
-        
+
         return nodes
 
     def _split_inline_patterns(self, text: str) -> list[str]:
         """Split text by special inline patterns."""
         # Pattern to match all special elements
-        pattern = r'(<<<(?:STATUS|MENTION|DATE):.+?>>>)'
+        pattern = r"(<<<(?:STATUS|MENTION|DATE):.+?>>>)"
         parts = re.split(pattern, text)
         return [part for part in parts if part]
 
     def _parse_markdown_formatting(self, text: str) -> list[dict[str, Any]]:
         """Parse markdown inline formatting (bold, italic, code, links)."""
-        nodes = []
-        
+        nodes: list[dict[str, Any]] = []
+
         # Simple implementation - in production, use proper markdown parser
         # This is a simplified version for demonstration
-        
+
         # Handle links first
-        link_pattern = r'\[([^\]]+)\]\(([^)]+)\)'
+        link_pattern = r"\[([^\]]+)\]\(([^)]+)\)"
         parts = re.split(link_pattern, text)
-        
+
         i = 0
         while i < len(parts):
             if i + 2 < len(parts) and parts[i + 1] and parts[i + 2]:
                 # This is a link
                 if parts[i]:
                     nodes.extend(self._parse_text_formatting(parts[i]))
-                nodes.append({
-                    "type": "text",
-                    "text": parts[i + 1],
-                    "marks": [{"type": "link", "attrs": {"href": parts[i + 2]}}]
-                })
+                nodes.append(
+                    {
+                        "type": "text",
+                        "text": parts[i + 1],
+                        "marks": [{"type": "link", "attrs": {"href": parts[i + 2]}}],
+                    }
+                )
                 i += 3
             else:
                 if parts[i]:
                     nodes.extend(self._parse_text_formatting(parts[i]))
                 i += 1
-        
+
         return nodes
 
     def _parse_text_formatting(self, text: str) -> list[dict[str, Any]]:
         """Parse text formatting marks (bold, italic, code, etc)."""
         # This is simplified - in production, use proper parsing
-        nodes = []
-        
+        nodes: list[dict[str, Any]] = []
+
         # Handle code
-        if '`' in text:
-            parts = text.split('`')
+        if "`" in text:
+            parts = text.split("`")
             for i, part in enumerate(parts):
                 if i % 2 == 0 and part:
                     # Not code
                     nodes.append({"type": "text", "text": part})
                 elif i % 2 == 1 and part:
                     # Code
-                    nodes.append({
-                        "type": "text",
-                        "text": part,
-                        "marks": [{"type": "code"}]
-                    })
+                    nodes.append(
+                        {"type": "text", "text": part, "marks": [{"type": "code"}]}
+                    )
         else:
             # For now, just return as plain text
             # In production, handle **bold**, *italic*, ~~strike~~, etc.
             if text:
                 nodes.append({"type": "text", "text": text})
-        
+
         return nodes
 
     def _normalize_status_color(self, color: str) -> str:
         """Normalize status color to ADF values."""
         color_map = {
-            'gray': 'neutral',
-            'grey': 'neutral',
-            'blue': 'blue',
-            'green': 'green',
-            'red': 'red',
-            'yellow': 'yellow',
-            'purple': 'purple'
+            "gray": "neutral",
+            "grey": "neutral",
+            "blue": "blue",
+            "green": "green",
+            "red": "red",
+            "yellow": "yellow",
+            "purple": "purple",
         }
-        return color_map.get(color.lower(), 'neutral')
+        return color_map.get(color.lower(), "neutral")
 
     def _track_node_metrics(self, node_type: str) -> None:
         """Track node creation metrics."""
-        if node_type not in self.metrics['nodes_created']:
-            self.metrics['nodes_created'][node_type] = 0
-        self.metrics['nodes_created'][node_type] += 1
+        if node_type not in self.metrics["nodes_created"]:
+            self.metrics["nodes_created"][node_type] = 0
+        self.metrics["nodes_created"][node_type] += 1
 
     def _create_empty_document(self) -> dict[str, Any]:
         """Create empty ADF document."""
-        return {
-            "version": 1,
-            "type": "doc",
-            "content": []
-        }
+        return {"version": 1, "type": "doc", "content": []}
 
-    def _create_error_document(
-        self, 
-        original_text: str, 
-        error: str
-    ) -> dict[str, Any]:
+    def _create_error_document(self, original_text: str, error: str) -> dict[str, Any]:
         """Create error fallback document."""
         return {
             "version": 1,
             "type": "doc",
-            "content": [{
-                "type": "panel",
-                "attrs": {"panelType": "error"},
-                "content": [{
-                    "type": "paragraph",
-                    "content": [{
-                        "type": "text",
-                        "text": f"Conversion error: {error}"
-                    }]
-                }, {
-                    "type": "paragraph",
-                    "content": [{
-                        "type": "text",
-                        "text": original_text[:500] + "..." if len(original_text) > 500 else original_text
-                    }]
-                }]
-            }]
+            "content": [
+                {
+                    "type": "panel",
+                    "attrs": {"panelType": "error"},
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {"type": "text", "text": f"Conversion error: {error}"}
+                            ],
+                        },
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": original_text[:500] + "..."
+                                    if len(original_text) > 500
+                                    else original_text,
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ],
         }
 
     def validate_marks(self, marks: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Validate and filter mark combinations according to ADF rules."""
         if not marks:
             return marks
-        
+
         # Check for code mark
-        has_code = any(m['type'] == 'code' for m in marks)
-        
+        has_code = any(m["type"] == "code" for m in marks)
+
         if has_code:
             # Code can only combine with link
-            return [m for m in marks if m['type'] in ['code', 'link']]
-        
+            return [m for m in marks if m["type"] in ["code", "link"]]
+
         # Check for incompatible marks
-        has_text_color = any(m['type'] == 'textColor' for m in marks)
-        has_bg_color = any(m['type'] == 'backgroundColor' for m in marks)
-        has_link = any(m['type'] == 'link' for m in marks)
-        
+        has_text_color = any(m["type"] == "textColor" for m in marks)
+        has_bg_color = any(m["type"] == "backgroundColor" for m in marks)
+        has_link = any(m["type"] == "link" for m in marks)
+
         filtered_marks = []
         for mark in marks:
-            if mark['type'] == 'textColor' and has_link:
+            if mark["type"] == "textColor" and has_link:
                 continue  # textColor cannot combine with link
-            if mark['type'] == 'backgroundColor' and has_code:
+            if mark["type"] == "backgroundColor" and has_code:
                 continue  # backgroundColor cannot combine with code
             filtered_marks.append(mark)
-        
+
         return filtered_marks
 
     def get_performance_metrics(self) -> dict[str, Any]:
         """Get performance metrics."""
-        cache_info = getattr(self._cached_convert, 'cache_info', lambda: None)()
-        
+        cache_info = getattr(self._cached_convert, "cache_info", lambda: None)()
+
         metrics = self.metrics.copy()
         if cache_info:
-            metrics['cache_info'] = {
-                'hits': cache_info.hits,
-                'misses': cache_info.misses,
-                'maxsize': cache_info.maxsize,
-                'currsize': cache_info.currsize
+            metrics["cache_info"] = {
+                "hits": cache_info.hits,
+                "misses": cache_info.misses,
+                "maxsize": cache_info.maxsize,
+                "currsize": cache_info.currsize,
             }
-            metrics['cache_hit_rate'] = (
-                (cache_info.hits / max(1, cache_info.hits + cache_info.misses)) * 100
-            )
-        
-        total_conversions = max(1, self.metrics['conversions_total'])
-        metrics['average_conversion_time'] = (
-            self.metrics['conversion_time_total'] / total_conversions
+            metrics["cache_hit_rate"] = (
+                cache_info.hits / max(1, cache_info.hits + cache_info.misses)
+            ) * 100
+
+        total_conversions = max(1, self.metrics["conversions_total"])
+        metrics["average_conversion_time"] = (
+            self.metrics["conversion_time_total"] / total_conversions
         )
-        metrics['error_rate'] = (
-            (self.metrics['conversion_errors'] / total_conversions) * 100
-        )
-        
+        metrics["error_rate"] = (
+            self.metrics["conversion_errors"] / total_conversions
+        ) * 100
+
         return metrics

--- a/test_debug_panel.py
+++ b/test_debug_panel.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Debug panel parsing."""
 
-import re
 from src.mcp_atlassian.formatting.adf_plugins import PanelPlugin
 
 plugin = PanelPlugin()
@@ -16,11 +15,11 @@ if match:
     print(f"Match found: {match.groups()}")
     data = plugin.parse_block(match, text)
     print(f"Parsed data: {data}")
-    
+
     # Mock render function
-    def mock_render(content):
+    def mock_render(content: str, block_mode: bool = False) -> list[dict[str, str]]:
         return [{"type": "text", "text": content}]
-    
+
     node = plugin.render_block(data, mock_render)
     print(f"Rendered node: {node}")
 else:


### PR DESCRIPTION
## Summary
- correct plugin count in ADF AST guide
- use SHA256 for cache keys and add import annotations
- improve type hints in enhanced ADF generator
- fix Confluence page helpers variable naming
- add typing to debug panel test

## Testing
- `pre-commit run --files docs/adf-ast-implementation.md src/mcp_atlassian/formatting/adf_enhanced.py src/mcp_atlassian/formatting/adf.py src/mcp_atlassian/confluence/pages.py test_debug_panel.py`
- `uv run pytest` *(fails: ValueError during real API validation)*

------
https://chatgpt.com/codex/tasks/task_e_688aef56f1c88323a853423dc99a97c6