### PR TITLE
chore: address Copilot follow-ups

### DIFF
--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -130,12 +130,12 @@ class UsersMixin(JiraClient):
             # For Cloud, use query parameter; for Server/DC use username
             if self.config.is_cloud:
                 response = self.jira.user_find_by_user_string(
-                    query=username, start_at=0, max_results=50
+                    query=username, start_at=0, max_results=1
                 )
             else:
                 # For Server/DC, the API might be different
                 response = self.jira.user_find_by_user_string(
-                    query=username, start_at=0, max_results=50
+                    query=username, start_at=0, max_results=1
                 )
             if not isinstance(response, list):
                 msg = f"Unexpected return value type from `jira.user_find_by_user_string`: {type(response)}"

--- a/src/mcp_atlassian/jira/worklog.py
+++ b/src/mcp_atlassian/jira/worklog.py
@@ -147,8 +147,8 @@ class WorklogMixin(JiraClient):
             base_url = self.jira.resource_url("issue")
             url = f"{base_url}/{issue_key}/worklog"
 
-            # Use 'data' payload in line with tests expecting 'data' kwarg
-            result = self.jira.post(url, data=worklog_data, params=params)
+            # Use 'json_data' payload for consistency with other REST client calls
+            result = self.jira.post(url, json_data=worklog_data, params=params)
             if not isinstance(result, dict):
                 msg = f"Unexpected return value type from `jira.post`: {type(result)}"
                 logger.error(msg)

--- a/src/mcp_atlassian/models/jira/common.py
+++ b/src/mcp_atlassian/models/jira/common.py
@@ -66,7 +66,7 @@ class JiraUser(ApiModel):
                 logger.debug(f"Unexpected avatar data format: {type(avatars)}")
 
         return cls(
-            account_id=data.get("accountId", JIRA_DEFAULT_ID),
+            account_id=data.get("accountId", None),
             display_name=str(data.get("displayName", UNKNOWN)),
             email=data.get("emailAddress"),
             active=bool(data.get("active", True)),


### PR DESCRIPTION
This PR addresses three low-risk follow-ups from Copilot's review:

- worklog: use `json_data` for POST payload consistency and update comment
- users: reduce user search `max_results` to 1 for direct lookup performance
- models: JiraUser `account_id` defaults to None when missing instead of `JIRA_DEFAULT_ID`

Safe changes; no behavior regressions expected.